### PR TITLE
Move createTouchDelegate() to onMeasure() fixes #1

### DIFF
--- a/library/src/main/java/com/lnikkila/extendedtouchview/ExtendedTouchView.java
+++ b/library/src/main/java/com/lnikkila/extendedtouchview/ExtendedTouchView.java
@@ -70,8 +70,8 @@ public class ExtendedTouchView extends FrameLayout {
     }
 
     @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         createTouchDelegate();
     }
 


### PR DESCRIPTION
This should make sure we always get a valid `Rect` when calling `getHitRect(hitRect)`.